### PR TITLE
feat: add CV Clean Template component

### DIFF
--- a/app/(main)/cv-preview/page.tsx
+++ b/app/(main)/cv-preview/page.tsx
@@ -1,0 +1,12 @@
+import { CVCleanTemplate } from '@/components/custom/cv-templates/cv-clean-template'
+import { mockCvData } from '@/data/mock-cv-data'
+
+export default function CVPreviewPage() {
+  return (
+    <div className="min-h-screen bg-gray-100 py-8">
+      <div className="max-w-5xl mx-auto">
+         <CVCleanTemplate cvData={mockCvData} accentColor="text-blue-600" />
+      </div>
+    </div>
+  )
+}

--- a/components/custom/cv-templates/cv-clean-template.tsx
+++ b/components/custom/cv-templates/cv-clean-template.tsx
@@ -1,0 +1,250 @@
+import React from 'react'
+import Image from 'next/image'
+import { CVData } from '@/types/cv-data'
+import { formatDate } from '@/utils/date-formatting'
+import {
+  IconGlobe,
+  IconMail,
+  IconPhone,
+  IconBrandLinkedin,
+  IconBrandXing,
+} from '@tabler/icons-react'
+
+interface CVCleanTemplateProps {
+  cvData: CVData
+  accentColor?: string
+}
+
+// Helper functions to extract usernames from social URLs
+const getLinkedInUsername = (url: string): string => {
+  const match = url.match(/linkedin\.com\/in\/([^\/]+)/)
+  return match ? match[1] : 'LinkedIn'
+}
+
+const getXingUsername = (url: string): string => {
+  const match = url.match(/xing\.com\/profile\/([^\/]+)/)
+  return match ? match[1] : 'Xing'
+}
+
+export function CVCleanTemplate({
+  cvData,
+  accentColor = 'text-blue-600',
+}: CVCleanTemplateProps) {
+  return (
+    <div
+      className="w-[794px] h-[1123px] bg-white shadow-lg mx-auto relative overflow-hidden print:shadow-none"
+      style={{ fontSize: '11px', lineHeight: '1.3' }}
+    >
+      {/* Header Section */}
+      <div className="flex items-start justify-between px-12 pt-12 pb-4">
+        {/* Left side - Name and Title */}
+        <div className="flex-1 pr-8">
+          <h1 className="text-3xl font-bold text-black mb-1 leading-tight">
+            {cvData.personalInformation.name}{' '}
+            {cvData.personalInformation.surname}
+          </h1>
+          {cvData.personalInformation.professionalTitle && (
+            <h2 className="text-lg text-black font-normal mb-4 leading-tight">
+              {cvData.personalInformation.professionalTitle}
+            </h2>
+          )}
+
+          {/* Summary */}
+          {cvData.personalInformation.summary && (
+            <p
+              className="text-sm text-gray-600 font-semibold max-w-lg"
+              style={{ lineHeight: '1.5' }}
+            >
+              {cvData.personalInformation.summary}
+            </p>
+          )}
+        </div>
+
+        {/* Right side - Photo */}
+        <div className="flex-shrink-0 ">
+          {cvData.personalInformation.profile_url && (
+            <Image
+              src={cvData.personalInformation.profile_url}
+              alt={`${cvData.personalInformation.name} ${cvData.personalInformation.surname}`}
+              width={130}
+              height={130}
+              className="w-[130px] h-[130px] rounded-full object-cover"
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Main Content Grid */}
+      <div
+        className="grid grid-cols-[300px_1fr] gap-8 px-12 py-8"
+        style={{ lineHeight: '1.3' }}
+      >
+        {/* Left Column */}
+        <div className="space-y-6">
+          {/* Contact Information */}
+          <div>
+            <div
+              className="space-y-2 text-sm text-gray-600"
+              style={{ lineHeight: '1.4' }}
+            >
+              {cvData.personalInformation.email && (
+                <a
+                  href={`mailto:${cvData.personalInformation.email}`}
+                  className="flex items-center gap-1.5 text-gray-600 hover:text-blue-600 transition-colors"
+                >
+                  <IconMail className="w-3 h-3" />
+                  <span>{cvData.personalInformation.email}</span>
+                </a>
+              )}
+              {cvData.personalInformation.phone && (
+                <a
+                  href={`tel:${cvData.personalInformation.phone}`}
+                  className="flex items-center gap-1.5 text-gray-600 hover:text-blue-600 transition-colors"
+                >
+                  <IconPhone className="w-3 h-3" />
+                  <span>{cvData.personalInformation.phone}</span>
+                </a>
+              )}
+              {cvData.personalInformation.website && (
+                <a
+                  href={cvData.personalInformation.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 text-gray-600 hover:text-blue-600 transition-colors"
+                >
+                  <IconGlobe className="w-3 h-3" />
+                  <span>
+                    {cvData.personalInformation.website.replace('https://', '')}
+                  </span>
+                </a>
+              )}
+              {cvData.personalInformation.linkedin && (
+                <a
+                  href={cvData.personalInformation.linkedin}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 text-gray-600 hover:text-blue-600 transition-colors"
+                >
+                  <IconBrandLinkedin className="w-3 h-3" />
+                  <span>{getLinkedInUsername(cvData.personalInformation.linkedin)}</span>
+                </a>
+              )}
+              {cvData.personalInformation.xing && (
+                <a
+                  href={cvData.personalInformation.xing}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 text-gray-600 hover:text-blue-600 transition-colors"
+                >
+                  <IconBrandXing className="w-3 h-3" />
+                  <span>{getXingUsername(cvData.personalInformation.xing)}</span>
+                </a>
+              )}
+            </div>
+          </div>
+
+          {/* Education */}
+          <div>
+            <h3 className={`text-base font-semibold ${accentColor} mb-2`}>
+              Education
+            </h3>
+            <div className="space-y-3">
+              {cvData.education.map((edu, index) => (
+                <div
+                  key={index}
+                  className="text-xs"
+                  style={{ lineHeight: '1.3' }}
+                >
+                  <div className="font-semibold text-black mb-0.5">
+                    {edu.degree}
+                  </div>
+                  <div className="text-black mb-1">{edu.institution}</div>
+                  <div className="text-gray-500 font-medium">
+                    {formatDate(edu.startDate)} - {formatDate(edu.endDate)}
+                    {edu.location && ` • ${edu.location}`}
+                  </div>
+                  {edu.description && (
+                    <div className="text-gray-600 mt-1">{edu.description}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Skills Groups */}
+          {cvData.skillGroups
+            .sort((a, b) => (a.order || 0) - (b.order || 0))
+            .map((skillGroup, groupIndex) => (
+              <div key={groupIndex}>
+                <h3 className={`text-base font-semibold ${accentColor} mb-2`}>
+                  {skillGroup.name}
+                </h3>
+                <div className="space-y-1">
+                  {skillGroup.skills
+                    .sort((a, b) => a.order - b.order)
+                    .map((skill, skillIndex) => (
+                      <div
+                        key={skillIndex}
+                        className="text-xs text-black"
+                        style={{ lineHeight: '1.3' }}
+                      >
+                        {skill.name}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            ))}
+        </div>
+
+        {/* Right Column */}
+        <div className="space-y-6">
+          {/* Work Experience */}
+          <div>
+            <h3 className={`text-base font-semibold ${accentColor} mb-2`}>
+              Experience
+            </h3>
+            <div className="space-y-5">
+              {cvData.experience.map((work, index) => (
+                <div key={index}>
+                  <div className="mb-2">
+                    {/* Role - more emphasis */}
+                    <h4
+                      className="text-sm font-bold text-black mb-0.5"
+                      style={{ lineHeight: '1.2' }}
+                    >
+                      {work.role}
+                    </h4>
+                    {/* Company - secondary */}
+                    <div
+                      className="text-sm font-medium text-gray-700 mb-1"
+                      style={{ lineHeight: '1.3' }}
+                    >
+                      {work.company}
+                    </div>
+                    {/* Date and location */}
+                    <div
+                      className="text-xs text-gray-500 font-medium"
+                      style={{ lineHeight: '1.3' }}
+                    >
+                      {formatDate(work.startDate)} - {formatDate(work.endDate)}
+                      {work.location && ` | ${work.location}`}
+                    </div>
+                  </div>
+                  {/* Description as continuous text */}
+                  {work.description && (
+                    <div
+                      className="text-xs text-black"
+                      style={{ lineHeight: '1.5' }}
+                    >
+                      {work.description}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/data/mock-cv-data.ts
+++ b/data/mock-cv-data.ts
@@ -1,0 +1,120 @@
+import { CVData } from '@/types/cv-data'
+
+export const mockCvData: CVData = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  last_modified: new Date('2025-09-05T10:30:00Z'),
+  created_at: new Date('2025-09-01T08:00:00Z'),
+  user_id: 'user_123456789',
+  visibility: 'public',
+
+  layout_configs: {
+    template_id: 0,
+    color_id: 2,
+    font_size: 11,
+  },
+
+  personalInformation: {
+    name: 'Katrin',
+    surname: 'Schmidt',
+    profile_url: '/katrin.jpg',
+    birthdate: '1990-03-15',
+    email: 'katrin.schmidt@email.com',
+    phone: '+49 030 123 4567',
+    location: 'Berlin, Germany',
+    linkedin: 'https://linkedin.com/in/katrinschmidt',
+    website: 'https://katrinschmidt.marketing',
+    xing: 'https://www.xing.com/profile/Katrin_Schmidt',
+    professionalTitle: 'Senior Marketing Manager',
+    summary:
+      'Results-driven Marketing Manager with 6+ years of experience in digital marketing and brand strategy. Specialized in growth marketing, and data-driven campaigns. Proven track record of increasing brand awareness and driving customer acquisition across B2B and B2C markets.',
+  },
+
+  experience: [
+    {
+      role: 'Senior Marketing Manager',
+      company: 'TechFlow Solutions',
+      startDate: new Date('2022-01-01'),
+      currentlyWorkingHere: true,
+      endDate: undefined,
+      location: 'Berlin, Germany',
+      description:
+        'Led integrated marketing campaigns that increased qualified leads by 85% and reduced customer acquisition cost by 30%. Managed annual marketing budget of €500K across digital and traditional channels. Developed and executed content marketing strategy resulting in 200% increase in organic website traffic. Built and managed a team of 4 marketing specialists, implementing data-driven processes that improved campaign ROI by 45%.',
+    },
+    {
+      role: 'Marketing Manager',
+      company: 'Digital Ventures GmbH',
+      startDate: new Date('2020-03-01'),
+      currentlyWorkingHere: false,
+      endDate: new Date('2021-12-31'),
+      location: 'Munich, Germany',
+      description:
+        'Managed multi-channel marketing campaigns across email, social media, and paid advertising platforms. Achieved 40% increase in brand awareness through strategic partnerships and influencer collaborations. Implemented marketing automation workflows that improved lead nurturing efficiency by 60%. Conducted market research and competitive analysis to inform product positioning and pricing strategies.',
+    },
+    {
+      role: 'Digital Marketing Specialist',
+      company: 'Creative Agency Berlin',
+      startDate: new Date('2018-06-01'),
+      currentlyWorkingHere: false,
+      endDate: new Date('2020-02-28'),
+      location: 'Berlin, Germany',
+      description:
+        'Executed digital marketing campaigns for B2B and B2C clients across various industries. Specialized in Google Ads, Facebook Ads, and LinkedIn advertising with average ROAS of 4.5x. Created and optimized landing pages and email campaigns that achieved industry-leading conversion rates. Collaborated with creative teams to develop compelling brand narratives and visual content.',
+    },
+  ],
+
+  education: [
+    {
+      degree: 'Master of Business Administration (MBA)',
+      institution: 'ESMT Berlin',
+      startDate: new Date('2016-09-01'),
+      currentlyStudyingHere: false,
+      endDate: new Date('2018-06-30'),
+      location: 'Berlin',
+      description: 'Specialization in Digital Marketing and Entrepreneurship',
+    },
+    {
+      degree: 'Bachelor of Arts in Communication & Media Studies',
+      institution: 'Humboldt University Berlin',
+      startDate: new Date('2012-09-01'),
+      currentlyStudyingHere: false,
+      endDate: new Date('2016-06-30'),
+      location: 'Berlin',
+    },
+  ],
+
+  skillGroups: [
+    {
+      name: 'Marketing Skills',
+      order: 1,
+      skills: [
+        { order: 1, name: 'Digital Marketing' },
+        { order: 2, name: 'Content Strategy' },
+        { order: 3, name: 'SEO/SEM' },
+        { order: 4, name: 'Social Media Marketing' },
+        { order: 5, name: 'Email Marketing' },
+        { order: 6, name: 'Marketing Automation' },
+        { order: 7, name: 'Brand Management' },
+      ],
+    },
+    {
+      name: 'Analytics & Tools',
+      order: 2,
+      skills: [
+        { order: 1, name: 'Google Analytics' },
+        { order: 2, name: 'HubSpot' },
+        { order: 3, name: 'Salesforce' },
+        { order: 4, name: 'Mailchimp' },
+        { order: 5, name: 'Canva' },
+      ],
+    },
+    {
+      name: 'Languages',
+      order: 3,
+      skills: [
+        { order: 1, name: 'German (Native)' },
+        { order: 2, name: 'English (Fluent)' },
+        { order: 3, name: 'Spanish (Conversational)' },
+      ],
+    },
+  ],
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,5 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/types/cv-data.ts
+++ b/types/cv-data.ts
@@ -1,0 +1,65 @@
+export interface CVData {
+  id: string
+  last_modified: Date
+  created_at: Date
+  user_id: string
+  visibility: 'draft' | 'private' | 'public'
+  password?: string
+  layout_configs: LayoutConfigs
+  personalInformation: PersonalInformation
+  experience: ExperienceItem[]
+  education: EducationItem[]
+  skillGroups: SkillGroup[]
+}
+
+export interface LayoutConfigs {
+  template_id: number
+  color_id: number
+  font_size: number
+}
+
+export interface PersonalInformation {
+  name: string
+  surname: string
+  profile_url: string
+  birthdate: string
+  email?: string
+  phone?: string
+  location?: string
+  linkedin?: string
+  xing?: string
+  website?: string
+  professionalTitle?: string
+  summary?: string
+}
+
+export interface ExperienceItem {
+  role: string
+  company: string
+  startDate: Date
+  currentlyWorkingHere: boolean
+  endDate?: Date
+  location?: string
+  description?: string
+}
+
+export interface EducationItem {
+  degree: string
+  institution: string
+  startDate: Date
+  currentlyStudyingHere: boolean
+  endDate?: Date
+  location?: string
+  description?: string
+}
+
+export interface SkillGroup {
+  name: string
+  order?: number
+  skills: Skill[]
+}
+
+export interface Skill {
+  order: number
+  name: string
+}

--- a/utils/date-formatting.ts
+++ b/utils/date-formatting.ts
@@ -1,0 +1,11 @@
+// Function to format a date to "MMM YYYY" format, e.g., "Jan 2020". Used in CV templates.
+export function formatDate(
+  date: Date | undefined,
+  currentPrefix: string = 'Present',
+): string {
+  if (!date) return currentPrefix
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(date))
+}


### PR DESCRIPTION
- Create CV Clean Template with German DIN A4 layout (794x1123px)
- Add TypeScript interfaces for CV data structure
- Implement formatDate utility function
- Used mock data
- CV preview page for testing (http://localhost:3000/cv-preview)